### PR TITLE
Swerve drive control using the XBox controller.

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -127,6 +127,7 @@ public final class Constants {
     public static final double kTwistDeadband = 0.5;
     public static final boolean kFieldRelative = true;
     public static final boolean kRateLimited = true;
+    public static final boolean kJoyStickDrive = false;
   }
 
   public static final class AutoConstants {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -127,7 +127,6 @@ public final class Constants {
     public static final double kTwistDeadband = 0.5;
     public static final boolean kFieldRelative = true;
     public static final boolean kRateLimited = true;
-    public static final boolean kJoyStickDrive = false;
   }
 
   public static final class AutoConstants {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -123,7 +123,8 @@ public final class Constants {
 
   public static final class OIConstants {
     public static final int kDriverControllerPort = 0;
-    public static final double kDriveDeadband = 0.1;
+    public static final double kDriveDeadband = 0.05;
+    public static final double kTurnDeadband = 0.15;
     public static final double kTwistDeadband = 0.5;
     public static final boolean kFieldRelative = true;
     public static final boolean kRateLimited = true;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -123,7 +123,7 @@ public final class Constants {
 
   public static final class OIConstants {
     public static final int kDriverControllerPort = 0;
-    public static final double kDriveDeadband = 0.05;
+    public static final double kDriveDeadband = 0.1;
     public static final double kTwistDeadband = 0.5;
     public static final boolean kFieldRelative = true;
     public static final boolean kRateLimited = true;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -87,6 +87,9 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
+
+    // Configures the input method (xbox or flightstick) when entering teleop
+    m_robotContainer.configureDefaultCommands();
   }
 
   /** This function is called periodically during operator control. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,6 +8,7 @@ import com.pathplanner.lib.auto.AutoBuilder;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.XboxController;
+import edu.wpi.first.wpilibj.PS4Controller.Button;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.OIConstants;
@@ -31,6 +32,8 @@ public class RobotContainer {
     // The driver's controller
     CommandJoystick m_driverController = new CommandJoystick(OIConstants.kDriverControllerPort);
 
+    XboxController m_driveXboxController = new XboxController(1);
+
     // The auto chooser
     private final SendableChooser<Command> autoChooser;
 
@@ -42,16 +45,30 @@ public class RobotContainer {
         this.configureButtonBindings();
 
         // Configure default commands
-        m_robotDrive.setDefaultCommand(
-            // The left stick controls translation of the robot.
-            // Turning is controlled by the X axis of the right stick.
-            new RunCommand(
-                () -> m_robotDrive.drive(
-                    -MathUtil.applyDeadband(m_driverController.getY(), OIConstants.kDriveDeadband),
-                    -MathUtil.applyDeadband(m_driverController.getX(), OIConstants.kDriveDeadband),
-                    -MathUtil.applyDeadband(m_driverController.getTwist(), OIConstants.kTwistDeadband),
-                    OIConstants.kFieldRelative, OIConstants.kRateLimited),
-                m_robotDrive));
+        if (OIConstants.kJoyStickDrive) {
+            // Configure default commands
+            m_robotDrive.setDefaultCommand(
+                // The left stick controls translation of the robot.
+                // Turning is controlled by the X axis of the right stick.
+                new RunCommand(
+                    () -> m_robotDrive.drive(
+                        -MathUtil.applyDeadband(m_driverController.getY(), OIConstants.kDriveDeadband),
+                        -MathUtil.applyDeadband(m_driverController.getX(), OIConstants.kDriveDeadband),
+                        -MathUtil.applyDeadband(m_driverController.getTwist(), OIConstants.kTwistDeadband),
+                        OIConstants.kFieldRelative, OIConstants.kRateLimited),
+                    m_robotDrive));
+        } else {
+            m_robotDrive.setDefaultCommand(
+                // The left stick controls translation of the robot.
+                // Turning is controlled by the X axis of the right stick.
+                new RunCommand(
+                        () -> m_robotDrive.drive(
+                                -MathUtil.applyDeadband(m_driveXboxController.getLeftY(), OIConstants.kDriveDeadband),
+                                -MathUtil.applyDeadband(m_driveXboxController.getLeftX(), OIConstants.kDriveDeadband),
+                                -MathUtil.applyDeadband(m_driveXboxController.getRightX(), OIConstants.kDriveDeadband),
+                                OIConstants.kFieldRelative, OIConstants.kRateLimited),
+                        m_robotDrive));
+        }
 
         // Build an auto chooser. This will use Commands.none() as the default option.
         autoChooser = AutoBuilder.buildAutoChooser();
@@ -78,6 +95,18 @@ public class RobotContainer {
         m_driverController.button(1)
             .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
             .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));    
+
+            new JoystickButton(m_driveXboxController, Button.kR1.value)
+            .whileTrue(new RunCommand(
+                () -> m_robotDrive.setX(),
+                m_robotDrive));
+    
+            new JoystickButton(m_driveXboxController, Button.kL1.value)
+                    .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
+                    .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));
+    
+            new JoystickButton(m_driveXboxController, Button.kTriangle.value)
+                    .onTrue(new InstantCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
     }
 
     /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -65,7 +65,7 @@ public class RobotContainer {
                         () -> m_robotDrive.drive(
                                 -MathUtil.applyDeadband(m_driveXboxController.getLeftY(), OIConstants.kDriveDeadband),
                                 -MathUtil.applyDeadband(m_driveXboxController.getLeftX(), OIConstants.kDriveDeadband),
-                                -MathUtil.applyDeadband(m_driveXboxController.getRightX(), OIConstants.kDriveDeadband),
+                                -MathUtil.applyDeadband(m_driveXboxController.getRightX(), OIConstants.kTurnDeadband),
                                 OIConstants.kFieldRelative, OIConstants.kRateLimited),
                         m_robotDrive));
         }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -30,10 +30,10 @@ public class RobotContainer {
     // The robot's subsystems
     private final Drivetrain m_robotDrive = new Drivetrain();
 
-    // The driver's controller
-    CommandJoystick m_driverController = new CommandJoystick(OIConstants.kDriverControllerPort);
-
-    CommandXboxController m_driveXboxController = new CommandXboxController(1);
+    // Flightstick controller
+    CommandJoystick m_driverFlightstickController = new CommandJoystick(OIConstants.kDriverControllerPort);
+    // XBox controller
+    CommandXboxController m_driverXboxController = new CommandXboxController(1);
 
     // The auto chooser
     private final SendableChooser<Command> autoChooser;
@@ -73,9 +73,9 @@ public class RobotContainer {
                 // Turning is controlled by the twist axis of the flightstick.
                 new RunCommand(
                     () -> m_robotDrive.drive(
-                        -MathUtil.applyDeadband(m_driverController.getY(), OIConstants.kDriveDeadband),
-                        -MathUtil.applyDeadband(m_driverController.getX(), OIConstants.kDriveDeadband),
-                        -MathUtil.applyDeadband(m_driverController.getTwist(), OIConstants.kTwistDeadband),
+                        -MathUtil.applyDeadband(m_driverFlightstickController.getY(), OIConstants.kDriveDeadband),
+                        -MathUtil.applyDeadband(m_driverFlightstickController.getX(), OIConstants.kDriveDeadband),
+                        -MathUtil.applyDeadband(m_driverFlightstickController.getTwist(), OIConstants.kTwistDeadband),
                         OIConstants.kFieldRelative, OIConstants.kRateLimited),
                     m_robotDrive));
         } else {
@@ -85,9 +85,9 @@ public class RobotContainer {
                 // Turning is controlled by the X axis of the right stick.
                 new RunCommand(
                         () -> m_robotDrive.drive(
-                                -MathUtil.applyDeadband(m_driveXboxController.getLeftY(), OIConstants.kDriveDeadband),
-                                -MathUtil.applyDeadband(m_driveXboxController.getLeftX(), OIConstants.kDriveDeadband),
-                                -MathUtil.applyDeadband(m_driveXboxController.getRightX(), OIConstants.kTurnDeadband),
+                                -MathUtil.applyDeadband(m_driverXboxController.getLeftY(), OIConstants.kDriveDeadband),
+                                -MathUtil.applyDeadband(m_driverXboxController.getLeftX(), OIConstants.kDriveDeadband),
+                                -MathUtil.applyDeadband(m_driverXboxController.getRightX(), OIConstants.kTurnDeadband),
                                 OIConstants.kFieldRelative, OIConstants.kRateLimited),
                         m_robotDrive));
         }
@@ -104,25 +104,25 @@ public class RobotContainer {
    */
     private void configureButtonBindings() {
         // Break Command (Button 2)
-        m_driverController.button(2).whileTrue(new RunCommand(() -> m_robotDrive.setX(), m_robotDrive));
+        m_driverFlightstickController.button(2).whileTrue(new RunCommand(() -> m_robotDrive.setX(), m_robotDrive));
 
         // Zero heading (Button 5)
-        m_driverController.button(5).whileTrue(new RunCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
+        m_driverFlightstickController.button(5).whileTrue(new RunCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
         
         // Slow Command (Button 1)
-        m_driverController.button(1)
+        m_driverFlightstickController.button(1)
             .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
             .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));    
 
         // Zero heading command (Y Button)
-        this.m_driveXboxController.y().onTrue(new InstantCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
+        this.m_driverXboxController.y().onTrue(new InstantCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
 
         // Brake command (Right Bumper)
-        this.m_driveXboxController.rightBumper().whileTrue(new RunCommand(() -> m_robotDrive.setX(),m_robotDrive));
+        this.m_driverXboxController.rightBumper().whileTrue(new RunCommand(() -> m_robotDrive.setX(),m_robotDrive));
 
         // Slow mode command (Left Bumper)
-        this.m_driveXboxController.leftBumper().onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive));
-        this.m_driveXboxController.leftBumper().onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));
+        this.m_driverXboxController.leftBumper().onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive));
+        this.m_driverXboxController.leftBumper().onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));
     }
 
     /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -143,6 +143,6 @@ public class RobotContainer {
     // Sets the speed percentage to use based on the slider on the flightstick,
     // this only works on the flightstick.
     public void setSpeedPercent() {
-        m_robotDrive.setSpeedPercent(1 - ((m_driverController.getThrottle() + 1) / 2));
+        m_robotDrive.setSpeedPercent(1 - ((m_driverFlightstickController.getThrottle() + 1) / 2));
     }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -17,6 +17,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
+import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 
 /*
@@ -32,7 +33,7 @@ public class RobotContainer {
     // The driver's controller
     CommandJoystick m_driverController = new CommandJoystick(OIConstants.kDriverControllerPort);
 
-    XboxController m_driveXboxController = new XboxController(1);
+    CommandXboxController m_driveXboxController = new CommandXboxController(1);
 
     // The auto chooser
     private final SendableChooser<Command> autoChooser;
@@ -113,20 +114,15 @@ public class RobotContainer {
             .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
             .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));    
 
-        // Brake Command (Right Bumper)
-        new JoystickButton(m_driveXboxController, Button.kRightBumper.value)
-        .whileTrue(new RunCommand(
-            () -> m_robotDrive.setX(),
-            m_robotDrive));
-    
-        // Slow Command (Left Bumper)
-        new JoystickButton(m_driveXboxController, Button.kLeftBumper.value)
-            .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
-            .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));
-    
-        // Zero heading (Button Y)
-        new JoystickButton(m_driveXboxController, Button.kY.value)
-            .onTrue(new InstantCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
+        // Zero heading command (Y Button)
+        this.m_driveXboxController.y().onTrue(new InstantCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
+
+        // Brake command (Right Bumper)
+        this.m_driveXboxController.rightBumper().whileTrue(new RunCommand(() -> m_robotDrive.setX(),m_robotDrive));
+
+        // Slow mode command (Left Bumper)
+        this.m_driveXboxController.leftBumper().onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive));
+        this.m_driveXboxController.leftBumper().onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));
     }
 
     /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -144,7 +144,8 @@ public class RobotContainer {
         m_robotDrive.setIdleStates(1);
     }
 
-    // Sets the speed percentage to use based on the slider on the joystick
+    // Sets the speed percentage to use based on the slider on the flightstick,
+    // this only works on the flightstick.
     public void setSpeedPercent() {
         m_robotDrive.setSpeedPercent(1 - ((m_driverController.getThrottle() + 1) / 2));
     }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,7 +8,7 @@ import com.pathplanner.lib.auto.AutoBuilder;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.XboxController;
-import edu.wpi.first.wpilibj.PS4Controller.Button;
+import edu.wpi.first.wpilibj.XboxController.Button;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Constants.OIConstants;
@@ -96,16 +96,16 @@ public class RobotContainer {
             .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
             .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));    
 
-            new JoystickButton(m_driveXboxController, Button.kR1.value)
+            new JoystickButton(m_driveXboxController, Button.kRightBumper.value)
             .whileTrue(new RunCommand(
                 () -> m_robotDrive.setX(),
                 m_robotDrive));
     
-            new JoystickButton(m_driveXboxController, Button.kL1.value)
+            new JoystickButton(m_driveXboxController, Button.kLeftBumper.value)
                     .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
                     .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));
     
-            new JoystickButton(m_driveXboxController, Button.kTriangle.value)
+            new JoystickButton(m_driveXboxController, Button.kY.value)
                     .onTrue(new InstantCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
     }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -44,12 +44,13 @@ public class RobotContainer {
      */
     public RobotContainer() {
         inputChooser = new SendableChooser<>();
+
+        // Assigning values to the input method chooser
         inputChooser.addOption("XBoxController", Boolean.FALSE);
         inputChooser.addOption("Flightstick", Boolean.TRUE);
+        inputChooser.setDefaultOption("Flightstick", Boolean.TRUE);
 
         SmartDashboard.putData("Input Chooser", inputChooser);
-
-        inputChooser.setDefaultOption("Flightstick", Boolean.TRUE);
 
         // Build an auto chooser. This will use Commands.none() as the default option.
         autoChooser = AutoBuilder.buildAutoChooser();
@@ -65,10 +66,10 @@ public class RobotContainer {
     public void configureDefaultCommands() {
         // Configure default commands
         if (inputChooser.getSelected().booleanValue() == true) {
-            // Configure default commands
+            // Configure the drivetrain to use the flightstick
             m_robotDrive.setDefaultCommand(
-                // The left stick controls translation of the robot.
-                // Turning is controlled by the X axis of the right stick.
+                // Joystick movement controls robot movement (up, right, left, down).
+                // Turning is controlled by the twist axis of the flightstick.
                 new RunCommand(
                     () -> m_robotDrive.drive(
                         -MathUtil.applyDeadband(m_driverController.getY(), OIConstants.kDriveDeadband),
@@ -77,6 +78,7 @@ public class RobotContainer {
                         OIConstants.kFieldRelative, OIConstants.kRateLimited),
                     m_robotDrive));
         } else {
+             // Configure the drivetrain to use the XBox controller
             m_robotDrive.setDefaultCommand(
                 // The left stick controls translation of the robot.
                 // Turning is controlled by the X axis of the right stick.
@@ -111,17 +113,20 @@ public class RobotContainer {
             .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
             .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));    
 
-            new JoystickButton(m_driveXboxController, Button.kRightBumper.value)
-            .whileTrue(new RunCommand(
-                () -> m_robotDrive.setX(),
-                m_robotDrive));
+        // Brake Command (Right Bumper)
+        new JoystickButton(m_driveXboxController, Button.kRightBumper.value)
+        .whileTrue(new RunCommand(
+            () -> m_robotDrive.setX(),
+            m_robotDrive));
     
-            new JoystickButton(m_driveXboxController, Button.kLeftBumper.value)
-                    .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
-                    .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));
+        // Slow Command (Left Bumper)
+        new JoystickButton(m_driveXboxController, Button.kLeftBumper.value)
+            .onTrue(new InstantCommand(() -> m_robotDrive.setSlowMode(true), m_robotDrive))
+            .onFalse(new InstantCommand(() -> m_robotDrive.setSlowMode(false), m_robotDrive));
     
-            new JoystickButton(m_driveXboxController, Button.kY.value)
-                    .onTrue(new InstantCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
+        // Zero heading (Button Y)
+        new JoystickButton(m_driveXboxController, Button.kY.value)
+            .onTrue(new InstantCommand(() -> m_robotDrive.zeroHeading(), m_robotDrive));
     }
 
     /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -36,16 +36,35 @@ public class RobotContainer {
 
     // The auto chooser
     private final SendableChooser<Command> autoChooser;
+    // The input method chooser
+    private final SendableChooser<Boolean> inputChooser;
 
     /**
      * The container for the robot. Contains subsystems, OI devices, and commands.
      */
     public RobotContainer() {
+        inputChooser = new SendableChooser<>();
+        inputChooser.addOption("XBoxController", Boolean.FALSE);
+        inputChooser.addOption("Flightstick", Boolean.TRUE);
+
+        SmartDashboard.putData("Input Chooser", inputChooser);
+
+        inputChooser.setDefaultOption("Flightstick", Boolean.TRUE);
+
+        // Build an auto chooser. This will use Commands.none() as the default option.
+        autoChooser = AutoBuilder.buildAutoChooser();
+        SmartDashboard.putData("Auto Chooser", autoChooser);
+
         // Configure the button bindings
         this.configureButtonBindings();
+        // Configure the default commands for the input method chosen
+        this.configureDefaultCommands();
+    }
 
+    // Configures default commands
+    public void configureDefaultCommands() {
         // Configure default commands
-        if (OIConstants.kJoyStickDrive) {
+        if (inputChooser.getSelected().booleanValue() == true) {
             // Configure default commands
             m_robotDrive.setDefaultCommand(
                 // The left stick controls translation of the robot.
@@ -69,10 +88,6 @@ public class RobotContainer {
                                 OIConstants.kFieldRelative, OIConstants.kRateLimited),
                         m_robotDrive));
         }
-
-        // Build an auto chooser. This will use Commands.none() as the default option.
-        autoChooser = AutoBuilder.buildAutoChooser();
-        SmartDashboard.putData("Auto Chooser", autoChooser);
     }
 
   /**


### PR DESCRIPTION
- xbox controls for the swerve drive
- quickly switching between flightstick and xbox controller using shuffleboard
- initialization functions in RobotContainer have been changed a bit
- some documentation and cleanup

** These features won't be useful for the actual competition because we will be using only 1 input method but it will help speed up testing and we won't need to get the flightstick everytime we want to test the swerve bot. **